### PR TITLE
Add blog listing and post detail pages

### DIFF
--- a/app/blog/[slug]/page.js
+++ b/app/blog/[slug]/page.js
@@ -1,14 +1,52 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
 import posts from '../../../data/posts.json';
 
+export function generateStaticParams() {
+  return posts.map((post) => ({ slug: post.slug }));
+}
+
+export function generateMetadata({ params }) {
+  const post = posts.find((x) => x.slug === params.slug);
+  if (!post) {
+    return { title: 'Post not found' };
+  }
+
+  return {
+    title: post.title,
+    description: post.excerpt || undefined,
+  };
+}
+
 export default function BlogPost({ params }) {
-  const p = posts.find((x) => x.slug === params.slug);
-  if (!p) return <div style={{ padding: 16 }}>Not found</div>;
+  const post = posts.find((x) => x.slug === params.slug);
+
+  if (!post) {
+    notFound();
+  }
+
   return (
-    <article style={{ padding: '16px 0' }}>
-      <h1>{p.title}</h1>
-      {p.image && <img src={p.image} alt="" style={{ width: '100%', borderRadius: 8, marginTop: 8 }} />}
-      {p.excerpt && <p style={{ marginTop: 12 }}>{p.excerpt}</p>}
-      {p.body && <div style={{ marginTop: 12, whiteSpace: 'pre-wrap' }}>{p.body}</div>}
+    <article style={{ padding: '16px 0', maxWidth: 760 }}>
+      <Link href="/blog" className="badge" style={{ display: 'inline-block', marginBottom: 16 }}>
+        ← Back to all posts
+      </Link>
+      <h1>{post.title}</h1>
+      {post.image && (
+        <img
+          src={post.image}
+          alt={post.title}
+          style={{ width: '100%', borderRadius: 12, marginTop: 16 }}
+        />
+      )}
+      {post.excerpt && (
+        <p style={{ marginTop: 16, fontSize: '1.05rem', color: 'var(--text-muted)' }}>
+          {post.excerpt}
+        </p>
+      )}
+      {post.body && (
+        <div style={{ marginTop: 24, whiteSpace: 'pre-wrap', lineHeight: 1.6 }}>{post.body}</div>
+      )}
     </article>
   );
 }

--- a/app/blog/page.js
+++ b/app/blog/page.js
@@ -1,18 +1,34 @@
+import Link from 'next/link';
+
 import posts from '../../data/posts.json';
+
+export const metadata = {
+  title: 'Blog',
+  description: 'Read the latest updates from the ModelSearcher team.',
+};
 
 export default function BlogList() {
   return (
     <section>
       <h1>Blog</h1>
-      <div className="grid">
+      <p style={{ marginTop: 12, maxWidth: 640 }}>
+        Our thoughts, updates, and model spotlights collected in one place.
+      </p>
+      <div className="grid" style={{ marginTop: 24 }}>
         {posts.map((p) => (
-          <a key={p.slug} href={`/blog/${p.slug}`} className="card">
-            {p.image && <img src={p.image} alt="" />}
+          <Link key={p.slug} href={`/blog/${p.slug}`} className="card">
+            {p.image && (
+              <img
+                src={p.image}
+                alt={p.title}
+                style={{ objectFit: 'cover' }}
+              />
+            )}
             <div className="p">
               <div style={{ fontWeight: 600 }}>{p.title}</div>
-              <div className="badge">{p.excerpt || ''}</div>
+              <div className="badge">{p.excerpt || 'Read more'}</div>
             </div>
-          </a>
+          </Link>
         ))}
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add a blog index page that lists posts from the JSON data set with links to each article
- implement the blog detail route to render full post content, metadata, and handle invalid slugs
- tweak styling to align with the existing card layout and add navigation back to the blog list

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca614dd56c833389fa3e3c627b60df